### PR TITLE
2.1.0 Uncompressed animation import, bug fixes, feature additions

### DIFF
--- a/Blender/FrontiersAnimationTools/FrontiersAnimDecompress/process_buffer.py
+++ b/Blender/FrontiersAnimationTools/FrontiersAnimDecompress/process_buffer.py
@@ -1,5 +1,10 @@
-# Pass raw byte-streams to DLL for ACL compression and decompression
-# DLL Source: https://github.com/AdelQue/FrontiersAnimDecompress/
+"""
+Pass raw byte-streams to and from DLL for ACL compression and decompression
+DLL Source: https://github.com/AdelQue/FrontiersAnimDecompress/
+
+See below for struct of different byte streams
+"""
+
 
 import bpy
 import io
@@ -42,3 +47,63 @@ def compress(uncompressed_buffer):
         return io.BytesIO(compressed_stream)
     else:
         return io.BytesIO()
+
+
+"""
+# ------------------------------------
+# ----- Compressed buffer struct -----
+# ------------------------------------
+
+acl_chunk_size  # uint32, total size of buffer including this section
+acl_hash        # int32
+
+acl_tag         # int32, Enum, should be 0xAC11AC11 (compressed_tracks)
+https://github.com/nfrechette/acl/blob/976ff051048477f2281c7d3609fddf0b3cba2c2d/includes/acl/core/buffer_tag.h#L49
+
+acl_version     # uint16, Enum, should be 7 (v02_00_00)
+https://github.com/nfrechette/acl/blob/976ff051048477f2281c7d3609fddf0b3cba2c2d/includes/acl/core/compressed_tracks_version.h#L71
+
+acl_unknown1    # byte, Always 0, Padding?
+
+acl_track_type  # byte, Enum, should be 12 (qvvf)
+https://github.com/nfrechette/acl/blob/976ff051048477f2281c7d3609fddf0b3cba2c2d/includes/acl/core/track_types.h#L68
+
+track_count # uint32, Bone count if skeletal, otherwise always 1
+frame_count # uint32
+frame_rate  # float32
+
+for acl_data in range(acl_chunk_size - 0x1C): # string of acl compressed data
+    acl_data    # byte
+"""
+
+
+"""
+# ------------------------------------
+# ---- Decompressed buffer struct ----
+# ------------------------------------
+
+anim_duration   # float32
+frame_rate      # float32
+frame_count     # uint32
+track_count     # uint32, Bone count if skeletal, otherwise always 1
+
+for frame in range(frame_count):
+    for bone in range(track_count):
+        # Quaternion Rotation
+        quat_x  # float32, Rotation X
+        quat_y  # float32, Rotation Y
+        quat_z  # float32, Rotation Z
+        quat_w  # float32, Rotation W
+
+        # Location
+        loc_x   # float32, Location X
+        loc_y   # float32, Location Y
+        loc_z   # float32, Location Z
+        loc_w   # float32, Bone Length After Scale
+
+        # Scale
+        scale_x # float32, Scale X
+        scale_y # float32, Scale Y
+        scale_z # float32, Scale Z
+        scale_w # float32, Unknown/Unneeded, Always 1.0
+"""

--- a/Blender/FrontiersAnimationTools/__init__.py
+++ b/Blender/FrontiersAnimationTools/__init__.py
@@ -14,7 +14,7 @@ from .ui import side_panel
 bl_info = {
     "name": "Sonic Frontiers Animation Tools",
     "author": "AdelQ, WistfulHopes, Turk645",
-    "version": (2, 0, 0),
+    "version": (2, 1, 0),
     "blender": (4, 1, 0),
     "location": "File > Import/Export",
     "description": "Animation and skeleton importer/exporter for Hedgehog Engine 2 games with compressed animations",
@@ -58,6 +58,17 @@ def register():
         name="PXD Frame Rate",
         description="FPS value to write to PXD Animation file",
         default=30.0,
+    )
+    bpy.types.Action.pxd_compress = BoolProperty(
+        name="Compress Animation",
+        description="Determines if animation gets compressed during batch export\n\n"
+        "(NOTE: Currently this setting is ignored and will always export compressed)",
+        default=True,
+    )
+    bpy.types.Action.pxd_additive = BoolProperty(
+        name="Additive Animation",
+        description="Determines if animation is additive",
+        default=False,
     )
 
 

--- a/Blender/FrontiersAnimationTools/animation/anim_export.py
+++ b/Blender/FrontiersAnimationTools/animation/anim_export.py
@@ -11,13 +11,17 @@ from bpy.props import (BoolProperty,
                        )
 from ..FrontiersAnimDecompress.process_buffer import compress
 
+RMS = 1 / math.sqrt(2)
+NULL = 0
 
-def anim_export(self, filepath, arm_active, action_active, start_frame, end_frame, frame_rate):
-    rms = 1 / math.sqrt(2)
-    null = 0
 
+# Function used by batch export, keep outside of operator class
+def anim_export(self_pass, filepath, arm_active, action_active, start_frame, end_frame, frame_rate):
     frame_count = end_frame - start_frame + 1
-    duration = (frame_count - 1) / frame_rate
+    if frame_count > 1:
+        duration = (frame_count - 1) / frame_rate
+    else:
+        duration = 0.0
     bone_count = len(arm_active.pose.bones)
 
     buffer_main = io.BytesIO()
@@ -28,14 +32,19 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
     buffer_main.write(struct.pack('<i', frame_count))
     buffer_main.write(struct.pack('<i', bone_count))
 
-    if self.bool_root_motion:
+    if self_pass.bool_root_motion:
         buffer_root.write(struct.pack('<f', duration))
         buffer_root.write(struct.pack('<f', frame_rate))
         buffer_root.write(struct.pack('<i', frame_count))
         buffer_root.write(struct.pack('<i', 1))
 
-    for frame in range(frame_count):
-        bpy.context.scene.frame_set(start_frame + frame)
+    for frame in range(end_frame + 1):
+        if self_pass.bool_start_zero:
+            bpy.context.scene.frame_set(frame)
+            if frame < start_frame:
+                continue
+        elif frame >= start_frame:
+            bpy.context.scene.frame_set(frame)
 
         # Build unscaled matrix map and separate scale map
         matrix_map_temp = {}
@@ -58,7 +67,7 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
             tmp_loc, tmp_rot, tmp_scale = tmp_matrix.decompose()
             tmp_scale = scale_map_temp[pbone.name]
 
-            if self.bool_yx_skel:
+            if self_pass.bool_yx_skel:
                 if not pbone.parent:
                     # Identity matrix to swap YX to XZ
                     tmp_rot @= mathutils.Quaternion((0.5, 0.5, 0.5, 0.5))
@@ -74,9 +83,9 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
                 buffer_main.write(struct.pack('<fff', tmp_scale[0], tmp_scale[1], tmp_scale[2]))
                 buffer_main.write(struct.pack('<f', 1.0))
 
-        if self.bool_root_motion:
+        if self_pass.bool_root_motion:
             tmp_loc = arm_active.location.copy()
-            tmp_rot = mathutils.Quaternion((rms, -rms, 0.0, 0.0)) @ arm_active.rotation_quaternion.copy()
+            tmp_rot = mathutils.Quaternion((RMS, -RMS, 0.0, 0.0)) @ arm_active.rotation_quaternion.copy()
             tmp_scale = arm_active.scale.copy()
 
             buffer_root.write(struct.pack('<ffff', tmp_rot[1], tmp_rot[2], tmp_rot[3], tmp_rot[0]))
@@ -87,13 +96,13 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
 
     main_buffer_compressed = compress(buffer_main.getvalue())
     if not len(main_buffer_compressed.getvalue()):
-        self.report({'WARNING'}, f"{action_active.name} buffer failed to compress.")
-        return {'CANCELLED'}
+        self_pass.report({'WARNING'}, f"{action_active.name} buffer failed to compress.")
+        return False
 
     root_buffer_compressed = compress(buffer_root.getvalue())
     if not len(root_buffer_compressed.getvalue()) and self.bool_root_motion is True:
-        self.report({'WARNING'}, f"{action_active.name} root buffer failed to compress.")
-        return {'CANCELLED'}
+        self_pass.report({'WARNING'}, f"{action_active.name} root buffer failed to compress.")
+        return False
 
     del buffer_main
     del buffer_root
@@ -102,7 +111,7 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
         main_buffer_size = main_buffer_compressed.getbuffer().nbytes
         root_buffer_size = root_buffer_compressed.getbuffer().nbytes
 
-        if self.bool_root_motion and root_buffer_size:
+        if self_pass.bool_root_motion and root_buffer_size:
             main_chunk_size = main_buffer_size + 0x10 - main_buffer_size % 0x10
             root_chunk_size = root_buffer_size + 4 - root_buffer_size % 4
             file_size = 0x80 + main_chunk_size + root_chunk_size + 4
@@ -124,14 +133,24 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
 
         file.write(struct.pack('<i', 4))
         file.write(struct.pack('<i', 0x18))
-        file.write(null.to_bytes(24, 'little'))
+        file.write(NULL.to_bytes(24, 'little'))
 
         # PXAN
         pxan_magic = bytes('NAXP', 'ascii')
         file.write(pxan_magic)
         file.write(struct.pack('<i', 0x200))
-        file.write(struct.pack('<i', 0x800))
-        file.write(struct.pack('<i', 0))
+        if self_pass.bool_additive:
+            file.write(struct.pack('<B', 1))
+        else:
+            file.write(struct.pack('<B', 0))
+
+        if self_pass.bool_compress:
+            file.write(struct.pack('<B', 8))
+        else:
+            file.write(struct.pack('<B', 0))
+
+        file.write(NULL.to_bytes(2, 'little'))
+        file.write(NULL.to_bytes(4, 'little'))
 
         file.write(struct.pack('<i', 0x18))
         file.write(struct.pack('<i', 0))
@@ -152,15 +171,16 @@ def anim_export(self, filepath, arm_active, action_active, start_frame, end_fram
         # Compressed track
         file.write(main_buffer_compressed.getvalue())
         if root_buffer_size:
-            file.write(null.to_bytes(0x10 - main_buffer_size % 0x10, 'little'))
+            file.write(NULL.to_bytes(0x10 - main_buffer_size % 0x10, 'little'))
             # Root track
             file.write(root_buffer_compressed.getvalue())
-            file.write(null.to_bytes(4 - root_buffer_size % 4, 'little'))
+            file.write(NULL.to_bytes(4 - root_buffer_size % 4, 'little'))
             file.write(struct.pack('<i', 0x00424644))
         else:
-            file.write(null.to_bytes(4 - main_buffer_size % 4, 'little'))
+            file.write(NULL.to_bytes(4 - main_buffer_size % 4, 'little'))
             file.write(struct.pack('<i', 0x00004644))
 
+    return True
 
 class FrontiersAnimExport(bpy.types.Operator, ExportHelper):
     bl_idname = "export_anim.frontiers_anim"
@@ -187,6 +207,28 @@ class FrontiersAnimExport(bpy.types.Operator, ExportHelper):
         default=True,
     )
 
+    bool_additive: BoolProperty(
+        name="Flag As Additive",
+        description="Flag animation file as additive",
+        default=False,
+    )
+
+    bool_compress: BoolProperty(
+        name="Compress Animation",
+        description="ACL compress animation to reduce file size\n\n"
+        "(NOTE: Uncompressed animation export currently unsupported)",
+        default=True,
+    )
+
+    bool_start_zero: BoolProperty(
+        name="Sample From Frame 0",
+        description="Enable to start sampling the animation from frame 0 regardless of the specified frame range. "
+                    "Will not affect output frame range.\n\n"
+                    "(NOTE: Will take longer if animation starts in middle of timeline, but useful for advanced users "
+                    "using features such as physics simulations)",
+        default=False,
+    )
+
     def draw(self, context):
         layout = self.layout
         ui_scene_box = layout.box()
@@ -194,6 +236,14 @@ class FrontiersAnimExport(bpy.types.Operator, ExportHelper):
 
         ui_root_row = ui_scene_box.row()
         ui_root_row.prop(self, "bool_root_motion", )
+        ui_zero_row = ui_scene_box.row()
+        ui_zero_row.prop(self, "bool_start_zero", )
+        ui_additive_row = ui_scene_box.row()
+        ui_additive_row.prop(self, "bool_additive", )
+        ui_compress_row = ui_scene_box.row()
+        ui_compress_row.prop(self, "bool_compress", )
+        # TODO: Implement uncompressed animation export
+        ui_compress_row.enabled = False
 
         ui_bone_box = layout.box()
         ui_bone_box.label(text="Armature Settings", icon='ARMATURE_DATA')
@@ -203,15 +253,15 @@ class FrontiersAnimExport(bpy.types.Operator, ExportHelper):
 
     @classmethod
     def poll(cls, context):
-        obj = bpy.context.active_object
+        obj = context.active_object
         if obj and obj.type == 'ARMATURE':
             return True
         else:
             return False
 
     def execute(self, context):
-        arm_active = bpy.context.active_object
-        scene_active = bpy.context.scene
+        arm_active = context.active_object
+        scene_active = context.scene
         frame_active = scene_active.frame_current
         if not arm_active:
             raise ValueError("No active object. Please select an armature as your active object.")
@@ -224,17 +274,18 @@ class FrontiersAnimExport(bpy.types.Operator, ExportHelper):
         action_active = arm_active.animation_data.action
         frame_rate = scene_active.render.fps / scene_active.render.fps_base
 
-        anim_export(self,
-                    self.filepath,
-                    arm_active,
-                    action_active,
-                    scene_active.frame_start,
-                    scene_active.frame_end,
-                    frame_rate
-                    )
+        if not anim_export(self,
+                           self.filepath,
+                           arm_active,
+                           action_active,
+                           scene_active.frame_start,
+                           scene_active.frame_end,
+                           frame_rate
+                           ):
+            return {'CANCELLED'}
 
         scene_active.frame_current = frame_active
-        return{'FINISHED'}
+        return {'FINISHED'}
 
     def menu_func_export(self, context):
         self.layout.operator(

--- a/Blender/FrontiersAnimationTools/animation/batch_export.py
+++ b/Blender/FrontiersAnimationTools/animation/batch_export.py
@@ -7,6 +7,7 @@ from bpy.props import (BoolProperty,
                        )
 from .anim_export import anim_export
 from ..ui.func_ops import filter_actions
+from .console_output import BatchProgress
 
 
 class FrontiersAnimBatchExport(bpy.types.Operator, ExportHelper):
@@ -25,11 +26,36 @@ class FrontiersAnimBatchExport(bpy.types.Operator, ExportHelper):
         default=False,
     )
 
+    bool_start_zero: BoolProperty(
+        name="Sample From Frame 0",
+        description="Enable to start sampling the animation from frame 0 regardless of the specified frame range. "
+                    "Will not affect output frame range.\n\n"
+                    "(NOTE: Will take longer if animation starts in middle of timeline, but useful for advanced users "
+                    "using features such as physics simulations)",
+        default=False,
+    )
+
     def __init__(self):
         self.bool_root_motion = False
+        self.bool_compress = True
+        self.bool_additive = False
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        if bpy.data.actions and obj and obj.type == 'ARMATURE':
+            return True
+        else:
+            return False
 
     def draw(self, context):
         layout = self.layout
+
+        ui_scene_box = layout.box()
+        ui_scene_box.label(text="Animation Settings", icon='ACTION')
+
+        ui_zero_row = ui_scene_box.row()
+        ui_zero_row.prop(self, "bool_start_zero", )
 
         ui_bone_box = layout.box()
         ui_bone_box.label(text="Armature Settings", icon='ARMATURE_DATA')
@@ -39,40 +65,49 @@ class FrontiersAnimBatchExport(bpy.types.Operator, ExportHelper):
 
     def execute(self, context):
         base_dir = os.path.dirname(self.filepath)
-        arm_active = bpy.context.active_object
-        scene_active = bpy.context.scene
+        arm_active = context.active_object
+        scene_active = context.scene
         frame_active = scene_active.frame_current
         action_active = arm_active.animation_data.action
         filtered_actions = filter_actions(bpy.data.actions, context)
 
-        print("Exporting PXD Animations...")
-        num_anims = len(filtered_actions)
-        status_len = 1
+        progress = BatchProgress(self, num_items=len(filtered_actions), method='EXPORT')
+
         for i, action in enumerate(filtered_actions):
-            # Single line status printing
-            status = f"{i + 1} / {num_anims}\t{action.name}"
-            print(' ' * status_len, end=f'\r{status}\r')
-            status_len = len(status) + 32
+            progress.resume(item_num=i, name=action.name)
 
             if action.pxd_root:
                 self.bool_root_motion = True
             else:
                 self.bool_root_motion = False
 
+            if action.pxd_additive:
+                self.bool_additive = True
+            else:
+                self.bool_additive = False
+
+            # TODO: Implement uncompressed animation export
+            # if action.pxd_compress:
+                # self.bool_compress = True
+            # else:
+                # self.bool_compress = False
+
             action_path = f"{base_dir}\\{action.name}.anm.pxd"
             arm_active.animation_data.action = action
             frame_rate = action.pxd_fps
-            anim_export(self,
-                        action_path,
-                        arm_active,
-                        action,
-                        round(action.frame_start),
-                        round(action.frame_end),
-                        frame_rate,
-                        )
+            if not anim_export(self,
+                               action_path,
+                               arm_active,
+                               action,
+                               round(action.frame_start),
+                               round(action.frame_end),
+                               frame_rate,
+                               ):
+                progress.update_error(name=action.name)
 
-        print(' ' * status_len, end=f"\rFinished exporting {num_anims} animations.\n")
+        progress.finish()
+
+        # Restore previous scene params
         arm_active.animation_data.action = action_active
         scene_active.frame_current = frame_active
-        self.report({'INFO'}, f"Successfully exported {len(filtered_actions)} animations")
         return {'FINISHED'}

--- a/Blender/FrontiersAnimationTools/animation/console_output.py
+++ b/Blender/FrontiersAnimationTools/animation/console_output.py
@@ -1,0 +1,76 @@
+import bpy
+import time
+
+
+# Manage console output and status for better visibility on import/export progress during UI freeze
+class BatchProgress:
+    def __init__(self, self_pass, num_items=0, num_frames=0, method='IMPORT'):
+        self.num_files = num_items
+        self.num_frames = num_frames
+        self.status_len = 0
+        self.status = ""
+        self.error_list = []
+        if method:
+            self.method = method
+        else:
+            self.method = None
+        self.start_time = time.time()
+        self.self_pass = self_pass
+        self.item_num = 0
+        self.item_name = str()
+
+        if self.method == 'IMPORT':
+            print("Importing PXD animations...")
+        elif self.method == 'EXPORT':
+            print("Exporting PXD Animations...")
+
+    def update_frame_count(self, num_frames):
+        self.num_frames = num_frames
+
+    def resume(self, frame_num=0, name=str(), item_num=0):
+        if item_num:
+            self.item_num = item_num
+        if name:
+            self.item_name = name
+
+        if self.method == 'IMPORT':
+            status = f"{self.item_num + 1} / {self.num_files}\t{self.item_name}\t{frame_num + 1} / {self.num_frames}"
+        elif self.method == 'EXPORT':
+            status = f"{self.item_num + 1} / {self.num_files}\t{self.item_name}"
+        print(' ' * self.status_len, end=f'\r{status}\r')
+        self.status_len = len(status) + 32
+
+    def update_error(self, name=str(), error=None):
+        if name:
+            self.item_name = name
+        self.error_list.append(self.item_name)
+        if self.method == 'IMPORT':
+            self.self_pass.report({'ERROR'}, f"{self.item_name}: {error}")
+            self.self_pass.report({'WARNING'}, f"{self.item_name} import was skipped due to errors.")
+
+        elif self.method == 'EXPORT':
+            self.self_pass.report({'WARNING'}, f"{self.item_name} export was aborted due to errors.")
+
+    def finish(self):
+        if self.method == 'IMPORT':
+            if self.error_list:
+                self.self_pass.report({'INFO'}, "Some animations were skipped due to errors. Please see console for list of skipped animations.")
+                for anim in self.error_list:
+                    print(anim)
+            else:
+                self.self_pass.report({'INFO'}, "All animations imported successfully.")
+
+            # Finish single line status printing
+            end_time = time.time()
+            time_elapsed = end_time - self.start_time
+            print(' ' * self.status_len, end=f"\rFinished importing {self.num_files} animations in {round(time_elapsed, 2)} seconds.\n")
+
+        elif self.method == 'EXPORT':
+            if self.error_list:
+                self.self_pass.report({'INFO'}, "Some animations were skipped due to errors. Please see console for list of skipped animations.")
+                for anim in self.error_list:
+                    print(anim)
+            else:
+                self.self_pass.report({'INFO'}, "All animations exported successfully.")
+
+            print(' ' * self.status_len, end=f"\rFinished exporting {self.num_files - len(self.error_list)} animations.\n")

--- a/Blender/FrontiersAnimationTools/skeleton/skeleton_export.py
+++ b/Blender/FrontiersAnimationTools/skeleton/skeleton_export.py
@@ -81,14 +81,14 @@ class HedgehogSkeletonExport(bpy.types.Operator, ExportHelper):
 
     @classmethod
     def poll(cls, context):
-        obj = bpy.context.active_object
+        obj = context.active_object
         if obj and obj.type == 'ARMATURE':
             return True
         else:
             return False
 
     def execute(self, context):
-        arm_active = bpy.context.active_object
+        arm_active = context.active_object
         if not arm_active:
             self.report({'INFO'}, f"No active armature. Please select an armature.")
             return {'CANCELLED'}


### PR DESCRIPTION
Feature changes and bug fixes:
- Added uncompressed animation support (import only for now)
- Added support for flagging additive animations
- Added frame counter to progress tracker in console (for imports only)
- Fixed issue where not already having an active action on skeleton would not allow you to actually select an action
- Fixed error importing single frame animations, 0 second duration
	- Also now set single frame animations to 0 second duration
- Add button to automatically set correct transform modes on custom or outdated skeletons
- Changed useless "loop check" option to "pad loop"
	- This imports the animation 3 times, setting the active frame range to the second loop. This is useful for things like non-linear interpolation or baking physics after the simulation has settled
- Added option to play animations from frame 0 during export
	- Useful for animations with frame range in middle of timeline, but still need simulations sampled from beginning of timeline
- Updated descriptions for improved clarity on what each option does
- Set all keyframe interpolation modes to 'LINEAR'

Code updates: 
- Separate import functions into uncompressed and compressed import functions
- Unique container PXD file checking
- New class for console outputs
- Better error handling
- Added reference for structure of ACL buffer between Python and DLL